### PR TITLE
Adjust pathGlobFilter defaults

### DIFF
--- a/functions/__init__.py
+++ b/functions/__init__.py
@@ -1,7 +1,7 @@
 """Expose functional submodules.
 
 Callers should reference functions using fully qualified module paths,
-for example ``functions.read.stream_read_cloudfiles``.  Importing these
+for example ``functions.read.stream_read_files``.  Importing these
 submodules here allows :func:`importlib.import_module` to resolve modules
 such as ``functions.read`` while avoiding re-exporting function names at the
 package level.

--- a/functions/config.py
+++ b/functions/config.py
@@ -6,7 +6,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 # Map short ``job_type`` names to ingest function combinations.
 JOB_TYPE_MAP = {
     "bronze_standard_streaming": {
-        "read_function": "functions.read.stream_read_cloudfiles",
+        "read_function": "functions.read.stream_read_files",
         "transform_function": "functions.transform.bronze_standard_transform",
         "write_function": "functions.write.stream_write_table",
     },

--- a/functions/utility.py
+++ b/functions/utility.py
@@ -138,6 +138,18 @@ def apply_job_type(settings):
 
         settings = _merge_dicts(defaults, settings)
 
+        # Move ``pathGlobFilter`` to the ``readStream_load`` path.  When only a
+        # filename is supplied, prepend ``**/`` so the glob is applied
+        # recursively.
+        read_opts = settings.get("readStreamOptions", {})
+        glob = read_opts.pop("pathGlobFilter", None)
+        if glob:
+            load_path = settings.get("readStream_load", "").rstrip("/")
+            if "/" not in glob and "*" not in glob and "?" not in glob:
+                glob = f"**/{glob}"
+            settings["readStream_load"] = f"{load_path}/{glob}"
+            settings["readStreamOptions"] = read_opts
+
     return settings
 
 
@@ -145,7 +157,7 @@ def get_function(path):
     """Return a callable from a dotted module path.
 
     ``path`` should be a fully qualified object name such as
-    ``"functions.read.stream_read_cloudfiles"``.  The string is split
+    ``"functions.read.stream_read_files"``.  The string is split
     once from the right with ``path.rsplit(".", 1)`` so any dots before
     the last one become part of the module path and the final segment is
     the attribute name.  A ``ValueError`` is raised if no ``'.'`` is present.

--- a/tests/test_apply_job_type.py
+++ b/tests/test_apply_job_type.py
@@ -1,0 +1,48 @@
+import sys
+import types
+import pathlib
+import importlib.util
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+# Provide minimal pyspark stubs required by utility
+pyspark = types.ModuleType('pyspark')
+sql = types.ModuleType('pyspark.sql')
+func_mod = types.ModuleType('pyspark.sql.functions')
+types_mod = types.ModuleType('pyspark.sql.types')
+setattr(types_mod, 'StructType', type('StructType', (), {}))
+sql.types = types_mod
+sql.functions = func_mod
+pyspark.sql = sql
+sys.modules['pyspark'] = pyspark
+sys.modules['pyspark.sql'] = sql
+sys.modules['pyspark.sql.types'] = types_mod
+sys.modules['pyspark.sql.functions'] = func_mod
+
+# Create a minimal 'functions' package so relative imports work
+pkg_path = pathlib.Path(__file__).resolve().parents[1] / 'functions'
+functions_pkg = types.ModuleType('functions')
+functions_pkg.__path__ = [str(pkg_path)]
+sys.modules.setdefault('functions', functions_pkg)
+
+# Load utility dynamically
+utility_path = pkg_path / 'utility.py'
+spec = importlib.util.spec_from_file_location('functions.utility', utility_path)
+utility = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(utility)
+
+
+def test_path_glob_appended_to_load():
+    settings = {
+        'simple_settings': 'true',
+        'job_type': 'bronze_standard_streaming',
+        'dst_table_name': 'cat.bronze.tbl',
+        'readStreamOptions': {
+            'cloudFiles.format': 'json',
+            'pathGlobFilter': 'stations.json'
+        },
+        'file_schema': []
+    }
+    result = utility.apply_job_type(settings)
+    assert result['readStream_load'].endswith('/**/stations.json')
+    assert 'pathGlobFilter' not in result['readStreamOptions']


### PR DESCRIPTION
## Summary
- update `apply_job_type` to merge `pathGlobFilter` into `readStream_load`
- add recursion when a simple filename is provided
- test `apply_job_type` path glob logic

## Testing
- `pip install pytest --break-system-packages`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68729d544cb883299032f38f72ec1a6e