### PR TITLE
Support local delta paths for bronze writes

### DIFF
--- a/layer_01_bronze/bodies7days.json
+++ b/layer_01_bronze/bodies7days.json
@@ -1,7 +1,6 @@
 {
     "simple_settings": "true",
     "job_type": "bronze_standard_streaming",
-    "dst_table_name": "edsm.bronze.bodies7days",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "true",
     "readStreamOptions": {
@@ -639,5 +638,6 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history"
+    "history_schema": "history",
+    "dst_table_path": "./tables/bronze/bodies7days"
 }

--- a/layer_01_bronze/codex.json
+++ b/layer_01_bronze/codex.json
@@ -1,7 +1,6 @@
 {
     "simple_settings": "true",
     "job_type": "bronze_standard_streaming",
-    "dst_table_name": "edsm.bronze.codex",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "true",
     "readStreamOptions": {
@@ -63,5 +62,6 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history"
+    "history_schema": "history",
+    "dst_table_path": "./tables/bronze/codex"
 }

--- a/layer_01_bronze/powerPlay.json
+++ b/layer_01_bronze/powerPlay.json
@@ -1,7 +1,6 @@
 {
     "simple_settings": "true",
     "job_type": "bronze_standard_streaming",
-    "dst_table_name": "edsm.bronze.powerPlay",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "true",
     "readStreamOptions": {
@@ -103,5 +102,6 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history"
+    "history_schema": "history",
+    "dst_table_path": "./tables/bronze/powerPlay"
 }

--- a/layer_01_bronze/stations.json
+++ b/layer_01_bronze/stations.json
@@ -1,7 +1,6 @@
 {
     "simple_settings": "true",
     "job_type": "bronze_standard_streaming",
-    "dst_table_name": "edsm.bronze.stations",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "true",
     "readStreamOptions": {
@@ -319,5 +318,6 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history"
+    "history_schema": "history",
+    "dst_table_path": "./tables/bronze/stations"
 }

--- a/layer_01_bronze/systemsPopulated.json
+++ b/layer_01_bronze/systemsPopulated.json
@@ -1,7 +1,6 @@
 {
     "simple_settings": "true",
     "job_type": "bronze_standard_streaming",
-    "dst_table_name": "edsm.bronze.systemsPopulated",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "true",
     "readStreamOptions": {
@@ -1089,5 +1088,6 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history"
+    "history_schema": "history",
+    "dst_table_path": "./tables/bronze/systemsPopulated"
 }

--- a/layer_01_bronze/systemsWithCoordinates.json
+++ b/layer_01_bronze/systemsWithCoordinates.json
@@ -1,7 +1,6 @@
 {
     "simple_settings": "true",
     "job_type": "bronze_standard_streaming",
-    "dst_table_name": "edsm.bronze.systemsWithCoordinates",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "true",
     "readStreamOptions": {
@@ -74,5 +73,6 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history"
+    "history_schema": "history",
+    "dst_table_path": "./tables/bronze/systemsWithCoordinates"
 }

--- a/layer_01_bronze/systemsWithCoordinates7days.json
+++ b/layer_01_bronze/systemsWithCoordinates7days.json
@@ -1,7 +1,6 @@
 {
     "simple_settings": "true",
     "job_type": "bronze_standard_streaming",
-    "dst_table_name": "edsm.bronze.systemsWithCoordinates7days",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "true",
     "readStreamOptions": {
@@ -73,5 +72,6 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history"
+    "history_schema": "history",
+    "dst_table_path": "./tables/bronze/systemsWithCoordinates7days"
 }

--- a/layer_01_bronze/systemsWithoutCoordinates.json
+++ b/layer_01_bronze/systemsWithoutCoordinates.json
@@ -1,7 +1,6 @@
 {
     "simple_settings": "true",
     "job_type": "bronze_standard_streaming",
-    "dst_table_name": "edsm.bronze.systemsWithoutCoordinates",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "true",
     "readStreamOptions": {
@@ -79,5 +78,6 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history"
+    "history_schema": "history",
+    "dst_table_path": "./tables/bronze/systemsWithoutCoordinates"
 }


### PR DESCRIPTION
## Summary
- update write helpers to require `dst_table_path` and write directly to disk
- allow streaming upserts to use delta path as query name
- maintain bronze settings using `dst_table_path`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872ac9ab1f08329ac613e17236411d1