### PR TITLE
Replace DQX references

### DIFF
--- a/functions/dq_checks.py
+++ b/functions/dq_checks.py
@@ -1,7 +1,7 @@
 """Custom data quality check functions for Databricks DQX.
 
 This module defines helper functions used when profiling tables. They are
-registered dynamically inside :func:`functions.quality.apply_dqx_checks` so
+registered dynamically inside :func:`functions.quality.apply_quality_checks` so
 that importing :mod:`functions.quality` does not require PySpark.
 """
 from __future__ import annotations

--- a/layer_02_silver/powerPlay.json
+++ b/layer_02_silver/powerPlay.json
@@ -17,7 +17,7 @@
     "data_type_map": {
         "date": "timestamp"
     },
-    "dqx_checks": [
+    "quality_checks": [
         {
             "name": "id_not_null",
             "check": {

--- a/layer_02_silver/systemsWithCoordinates.json
+++ b/layer_02_silver/systemsWithCoordinates.json
@@ -17,7 +17,7 @@
         "date": "timestamp"
     },
     "ingest_time_column": "derived_ingest_time",
-    "dqx_checks": [
+    "quality_checks": [
         {
             "name": "coords.x_is_not_null",
             "check": {


### PR DESCRIPTION
## Summary
- rename helper `apply_dqx_checks` -> `apply_quality_checks`
- accept `quality_checks` settings key with fallback to legacy `dqx_checks`
- update test suite for new helper name
- rename `dqx_checks` to `quality_checks` in JSON configs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872c7959f0c8329a9aabaadac087205