### PR TITLE
Add local job runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,12 @@ python scripts/run_ingest.py bronze stations
 Specify the layer (`bronze`, `silver`, or `gold`) and the table name (without the
 `.json` extension). Use the `--master` argument to override the Spark master URL
 if necessary.
+## Running the full job
+
+Use the `utilities/run_job.py` script to execute the downloader and all ingest tasks without relying on Databricks APIs.
+
+```bash
+python utilities/run_job.py
+```
+
+Use `--master` to override the Spark master URL if necessary.

--- a/functions/utility.py
+++ b/functions/utility.py
@@ -229,6 +229,7 @@ def volume_exists(catalog, schema, volume, spark=None):
     """Return True if the volume directory already exists."""
 
     root = S3_ROOT_LANDING if volume == "landing" else S3_ROOT_UTILITY
+    root = root.rstrip("/") + "/"
     path = f"{root}{catalog}/{schema}/{volume}"
 
     return Path(path).exists()
@@ -239,6 +240,7 @@ def create_volume_if_not_exists(catalog, schema, volume, spark=None):
 
     if not volume_exists(catalog, schema, volume, spark):
         root = S3_ROOT_LANDING if volume == "landing" else S3_ROOT_UTILITY
+        root = root.rstrip("/") + "/"
         path = f"{root}{catalog}/{schema}/{volume}"
 
         Path(path).mkdir(parents=True, exist_ok=True)

--- a/utilities/run_job.py
+++ b/utilities/run_job.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Run the entire EDSM pipeline using PySpark only.
+
+This utility replicates the Databricks job defined in ``job-definition.yaml``
+without using any Databricks APIs. It sequentially executes the downloader
+script and then runs the ingest pipeline for each table defined in the layer
+settings files.
+"""
+
+import argparse
+import subprocess
+from glob import glob
+from pathlib import Path
+import sys
+
+# Ensure repo modules are on the path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from pyspark.sql import SparkSession
+
+from scripts.run_ingest import run_pipeline
+from functions.sanity import (
+    validate_settings,
+    initialize_schemas_and_volumes,
+    initialize_empty_tables,
+)
+
+
+def _discover_tables(color: str) -> list[str]:
+    """Return a sorted list of table names for ``color`` layer."""
+    paths = glob(f"./layer_*_{color}/*.json")
+    return sorted(Path(p).stem for p in paths)
+
+
+def run_job(master: str) -> None:
+    """Execute the downloader and ingest pipelines."""
+
+    validate_settings()
+
+    spark = (
+        SparkSession.builder.master(master)
+        .appName("edsm-job")
+        .getOrCreate()
+    )
+    try:
+        initialize_schemas_and_volumes(spark)
+        initialize_empty_tables(spark)
+
+        downloader = Path(__file__).with_name("downloader.sh")
+        subprocess.check_call(["bash", str(downloader)])
+
+        for table in _discover_tables("bronze"):
+            run_pipeline("bronze", table, spark)
+
+        for table in _discover_tables("silver"):
+            run_pipeline("silver", table, spark)
+    finally:
+        spark.stop()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the full EDSM job locally")
+    parser.add_argument(
+        "--master", default="local[*]", help="Spark master URL"
+    )
+    args = parser.parse_args()
+    run_job(args.master)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- handle volume roots without trailing slash
- add `run_job.py` that runs downloader and ingest tasks directly via PySpark
- document how to run the full job locally

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872d5ab9c588329895bdd8aa8b207c3