### PR TITLE
Enable Delta Lake in Spark sessions

### DIFF
--- a/dashboards/nearest_by_system_state.py
+++ b/dashboards/nearest_by_system_state.py
@@ -50,6 +50,15 @@ def main() -> None:
     spark = (
         SparkSession.builder.master(args.master)
         .appName("nearest-systems")
+        .config("spark.jars.packages", "io.delta:delta-spark_2.12:2.4.0")
+        .config(
+            "spark.sql.extensions",
+            "io.delta.sql.DeltaSparkSessionExtension",
+        )
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
         .getOrCreate()
     )
     try:

--- a/dashboards/powerplay_file_tracker.py
+++ b/dashboards/powerplay_file_tracker.py
@@ -23,7 +23,20 @@ def main() -> None:
     parser.add_argument("--master", default="local[*]", help="Spark master URL")
     args = parser.parse_args()
 
-    spark = SparkSession.builder.master(args.master).appName("powerplay-tracker").getOrCreate()
+    spark = (
+        SparkSession.builder.master(args.master)
+        .appName("powerplay-tracker")
+        .config("spark.jars.packages", "io.delta:delta-spark_2.12:2.4.0")
+        .config(
+            "spark.sql.extensions",
+            "io.delta.sql.DeltaSparkSessionExtension",
+        )
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+        .getOrCreate()
+    )
     try:
         params = vars(args)
         df1 = spark.sql(QUERY1.format(**params))

--- a/dashboards/stations_file_tracker.py
+++ b/dashboards/stations_file_tracker.py
@@ -22,7 +22,20 @@ def main() -> None:
     parser.add_argument("--master", default="local[*]", help="Spark master URL")
     args = parser.parse_args()
 
-    spark = SparkSession.builder.master(args.master).appName("stations-tracker").getOrCreate()
+    spark = (
+        SparkSession.builder.master(args.master)
+        .appName("stations-tracker")
+        .config("spark.jars.packages", "io.delta:delta-spark_2.12:2.4.0")
+        .config(
+            "spark.sql.extensions",
+            "io.delta.sql.DeltaSparkSessionExtension",
+        )
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+        .getOrCreate()
+    )
     try:
         params = vars(args)
         df = spark.sql(QUERY.format(**params))

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -29,6 +29,15 @@ def main() -> None:
     spark = (
         SparkSession.builder.master(args.master)
         .appName("edsm-ingest")
+        .config("spark.jars.packages", "io.delta:delta-spark_2.12:2.4.0")
+        .config(
+            "spark.sql.extensions",
+            "io.delta.sql.DeltaSparkSessionExtension",
+        )
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
         .getOrCreate()
     )
 

--- a/scripts/run_ingest.py
+++ b/scripts/run_ingest.py
@@ -81,6 +81,15 @@ def main() -> None:
     spark = (
         SparkSession.builder.master(args.master)
         .appName("edsm-ingest")
+        .config("spark.jars.packages", "io.delta:delta-spark_2.12:2.4.0")
+        .config(
+            "spark.sql.extensions",
+            "io.delta.sql.DeltaSparkSessionExtension",
+        )
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
         .getOrCreate()
     )
 

--- a/utilities/drop_history_tables.py
+++ b/utilities/drop_history_tables.py
@@ -19,7 +19,20 @@ def main() -> None:
     parser.add_argument("--master", default="local[*]", help="Spark master URL")
     args = parser.parse_args()
 
-    spark = SparkSession.builder.master(args.master).appName("drop-history").getOrCreate()
+    spark = (
+        SparkSession.builder.master(args.master)
+        .appName("drop-history")
+        .config("spark.jars.packages", "io.delta:delta-spark_2.12:2.4.0")
+        .config(
+            "spark.sql.extensions",
+            "io.delta.sql.DeltaSparkSessionExtension",
+        )
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+        .getOrCreate()
+    )
     try:
         drop_history_tables(spark, args.schema)
     finally:

--- a/utilities/history_cli.py
+++ b/utilities/history_cli.py
@@ -29,7 +29,20 @@ def main() -> None:
     history_schema = job_settings.get("history_schema")
     catalog = full_table_name.split(".")[0]
 
-    spark = SparkSession.builder.master(args.master).appName("history").getOrCreate()
+    spark = (
+        SparkSession.builder.master(args.master)
+        .appName("history")
+        .config("spark.jars.packages", "io.delta:delta-spark_2.12:2.4.0")
+        .config(
+            "spark.sql.extensions",
+            "io.delta.sql.DeltaSparkSessionExtension",
+        )
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+        .getOrCreate()
+    )
     try:
         if history_schema is None:
             print("Skipping history build: no history_schema provided")

--- a/utilities/inspect_checkpoint_folder.py
+++ b/utilities/inspect_checkpoint_folder.py
@@ -25,7 +25,20 @@ def main() -> None:
     settings_path = table_map[args.table]
     settings = json.loads(Path(settings_path).read_text())
 
-    spark = SparkSession.builder.master(args.master).appName("inspect-checkpoints").getOrCreate()
+    spark = (
+        SparkSession.builder.master(args.master)
+        .appName("inspect-checkpoints")
+        .config("spark.jars.packages", "io.delta:delta-spark_2.12:2.4.0")
+        .config(
+            "spark.sql.extensions",
+            "io.delta.sql.DeltaSparkSessionExtension",
+        )
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+        .getOrCreate()
+    )
     try:
         inspect_checkpoint_folder(settings, args.table, spark)
     finally:

--- a/utilities/optimize_and_vacuum.py
+++ b/utilities/optimize_and_vacuum.py
@@ -11,7 +11,20 @@ def main() -> None:
     parser.add_argument("--master", default="local[*]", help="Spark master URL")
     args = parser.parse_args()
 
-    spark = SparkSession.builder.master(args.master).appName("optimize-vacuum").getOrCreate()
+    spark = (
+        SparkSession.builder.master(args.master)
+        .appName("optimize-vacuum")
+        .config("spark.jars.packages", "io.delta:delta-spark_2.12:2.4.0")
+        .config(
+            "spark.sql.extensions",
+            "io.delta.sql.DeltaSparkSessionExtension",
+        )
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+        .getOrCreate()
+    )
     try:
         catalog = args.catalog
         schemas = spark.sql(f"SHOW SCHEMAS IN {catalog}").collect()

--- a/utilities/profile_silver_table.py
+++ b/utilities/profile_silver_table.py
@@ -23,7 +23,20 @@ def main() -> None:
     parser.add_argument("--master", default="local[*]", help="Spark master URL")
     args = parser.parse_args()
 
-    spark = SparkSession.builder.master(args.master).appName("profile-table").getOrCreate()
+    spark = (
+        SparkSession.builder.master(args.master)
+        .appName("profile-table")
+        .config("spark.jars.packages", "io.delta:delta-spark_2.12:2.4.0")
+        .config(
+            "spark.sql.extensions",
+            "io.delta.sql.DeltaSparkSessionExtension",
+        )
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+        .getOrCreate()
+    )
     try:
         settings_path = Path(f"../layer_02_silver/{args.table}.json")
         settings = json.loads(settings_path.read_text())

--- a/utilities/rescue_silver_schema.py
+++ b/utilities/rescue_silver_schema.py
@@ -28,7 +28,20 @@ def main() -> None:
     parser.add_argument("--master", default="local[*]", help="Spark master URL")
     args = parser.parse_args()
 
-    spark = SparkSession.builder.master(args.master).appName("rescue-schema").getOrCreate()
+    spark = (
+        SparkSession.builder.master(args.master)
+        .appName("rescue-schema")
+        .config("spark.jars.packages", "io.delta:delta-spark_2.12:2.4.0")
+        .config(
+            "spark.sql.extensions",
+            "io.delta.sql.DeltaSparkSessionExtension",
+        )
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+        .getOrCreate()
+    )
     try:
         paths = glob("../layer_02_silver/*.json")
         tables = [Path(p).stem for p in paths]

--- a/utilities/rescue_silver_table_cli.py
+++ b/utilities/rescue_silver_table_cli.py
@@ -17,7 +17,20 @@ def main() -> None:
     parser.add_argument("--master", default="local[*]", help="Spark master URL")
     args = parser.parse_args()
 
-    spark = SparkSession.builder.master(args.master).appName("rescue-table").getOrCreate()
+    spark = (
+        SparkSession.builder.master(args.master)
+        .appName("rescue-table")
+        .config("spark.jars.packages", "io.delta:delta-spark_2.12:2.4.0")
+        .config(
+            "spark.sql.extensions",
+            "io.delta.sql.DeltaSparkSessionExtension",
+        )
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+        .getOrCreate()
+    )
     try:
         print(f"Rescuing table: {args.table}")
         rescue_silver_table("timestamp", args.table, spark)

--- a/utilities/reset_catalog.py
+++ b/utilities/reset_catalog.py
@@ -54,7 +54,20 @@ def main() -> None:
     for layer in ["bronze", "silver", "gold"]:
         remove_volume(args.volume_root / layer / "utility")
 
-    spark = SparkSession.builder.master(args.master).appName("reset-catalog").getOrCreate()
+    spark = (
+        SparkSession.builder.master(args.master)
+        .appName("reset-catalog")
+        .config("spark.jars.packages", "io.delta:delta-spark_2.12:2.4.0")
+        .config(
+            "spark.sql.extensions",
+            "io.delta.sql.DeltaSparkSessionExtension",
+        )
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+        .getOrCreate()
+    )
     try:
         drop_tables(spark, args.catalog)
     finally:


### PR DESCRIPTION
## Summary
- configure SparkSession builders to load Delta Lake
- enable Delta Lake SQL extensions and catalog

## Testing
- `pytest -q` *(fails: test_volume_root_without_trailing_slash)*

------
https://chatgpt.com/codex/tasks/task_e_6872d64f8e5483298cf005b2ea3cc702