### PR TITLE
Add helper for pyspark stubs in tests

### DIFF
--- a/tests/test_bronze_transform.py
+++ b/tests/test_bronze_transform.py
@@ -1,46 +1,29 @@
 import sys
-import types
 import pathlib
 from unittest import mock
 import importlib.util
 import unittest
+from tests import utils
 
 # Create minimal fake pyspark modules before importing transform
-pyspark = types.ModuleType('pyspark')
-sql = types.ModuleType('pyspark.sql')
-types_mod = types.ModuleType('pyspark.sql.types')
-func_mod = types.ModuleType('pyspark.sql.functions')
-sql.types = types_mod
-sql.functions = func_mod
-pyspark.sql = sql
-sys.modules['pyspark'] = pyspark
-sys.modules['pyspark.sql'] = sql
-sys.modules['pyspark.sql.types'] = types_mod
-sys.modules['pyspark.sql.functions'] = func_mod
+utils.install_fake_pyspark(
+    function_names=[
+        'concat', 'regexp_extract', 'date_format', 'current_timestamp', 'when', 'col',
+        'to_timestamp', 'to_date', 'regexp_replace', 'sha2', 'lit', 'trim',
+        'struct', 'to_json', 'expr', 'transform', 'array'
+    ],
+    type_names=[
+        'StructType', 'StructField', 'StringType', 'LongType',
+        'TimestampType', 'ArrayType', 'MapType'
+    ]
+)
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
-# Provide dummy classes/functions referenced in transform
-for name in [
-    'StructType', 'StructField', 'StringType', 'LongType',
-    'TimestampType', 'ArrayType', 'MapType'
-]:
-    setattr(types_mod, name, type(name, (), {}))
-
-def dummy(*args, **kwargs):
-    return None
-for name in [
-    'concat','regexp_extract','date_format','current_timestamp','when','col',
-    'to_timestamp','to_date','regexp_replace','sha2','lit','trim','struct',
-    'to_json','expr','transform','array'
-]:
-    setattr(func_mod, name, dummy)
-
 # Import the module under test after faking pyspark
-transform_path = pathlib.Path(__file__).resolve().parents[1] / 'functions' / 'transform.py'
-spec = importlib.util.spec_from_file_location('functions.transform', transform_path)
-transform = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(transform)
+pkg_path = utils.install_functions_package()
+transform_path = pkg_path / 'transform.py'
+transform = utils.load_module('functions.transform', transform_path)
 
 class DummyDF:
     def __init__(self, columns=None):

--- a/tests/test_check_catalog_match.py
+++ b/tests/test_check_catalog_match.py
@@ -4,20 +4,17 @@ import types
 import importlib.util
 import json
 import pytest
+from tests import utils
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
-pkg_path = pathlib.Path(__file__).resolve().parents[1] / 'functions'
-functions_pkg = types.ModuleType('functions')
-functions_pkg.__path__ = [str(pkg_path)]
-sys.modules.setdefault('functions', functions_pkg)
+pkg_path = utils.install_functions_package()
+functions_pkg = sys.modules['functions']
 
 # Load modules dynamically
 for name in ['sanity', 'config']:
     path = pkg_path / f'{name}.py'
-    spec = importlib.util.spec_from_file_location(f'functions.{name}', path)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
+    mod = utils.load_module(f'functions.{name}', path)
     setattr(functions_pkg, name, mod)
 
 sanity = functions_pkg.sanity

--- a/tests/test_check_host_name.py
+++ b/tests/test_check_host_name.py
@@ -3,19 +3,15 @@ import pathlib
 import types
 import importlib.util
 import pytest
+from tests import utils
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 # Create minimal 'functions' package to load sanity without importing other modules
-pkg_path = pathlib.Path(__file__).resolve().parents[1] / 'functions'
-functions_pkg = types.ModuleType('functions')
-functions_pkg.__path__ = [str(pkg_path)]
-sys.modules.setdefault('functions', functions_pkg)
+pkg_path = utils.install_functions_package()
 
 sanity_path = pkg_path / 'sanity.py'
-spec = importlib.util.spec_from_file_location('functions.sanity', sanity_path)
-sanity = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(sanity)
+sanity = utils.load_module('functions.sanity', sanity_path)
 
 
 def test_check_host_name_env(monkeypatch, capsys):

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -4,22 +4,18 @@ import pathlib
 import importlib.util
 import unittest
 import unittest.mock
+from tests import utils
 
 # Insert repo root into path
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 # Create a minimal ``functions`` package to avoid executing the real package
 # (which requires pyspark) when ``quality`` performs relative imports.
-pkg_path = pathlib.Path(__file__).resolve().parents[1] / 'functions'
-functions_pkg = types.ModuleType('functions')
-functions_pkg.__path__ = [str(pkg_path)]
-sys.modules.setdefault('functions', functions_pkg)
+pkg_path = utils.install_functions_package()
 
 # Import quality module dynamically
-quality_path = pathlib.Path(__file__).resolve().parents[1] / 'functions' / 'quality.py'
-spec = importlib.util.spec_from_file_location('functions.quality', quality_path)
-quality = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(quality)
+quality_path = pkg_path / 'quality.py'
+quality = utils.load_module('functions.quality', quality_path)
 
 class DummyDF:
     def __init__(self, schema=None):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,47 @@
+import sys
+import types
+import pathlib
+import importlib.util
+
+
+def install_fake_pyspark(function_names=None, type_names=None):
+    """Install minimal pyspark stubs into ``sys.modules`` for tests."""
+    pyspark = types.ModuleType("pyspark")
+    sql = types.ModuleType("pyspark.sql")
+    funcs = types.ModuleType("pyspark.sql.functions")
+    types_mod = types.ModuleType("pyspark.sql.types")
+    sql.functions = funcs
+    sql.types = types_mod
+    pyspark.sql = sql
+    sys.modules["pyspark"] = pyspark
+    sys.modules["pyspark.sql"] = sql
+    sys.modules["pyspark.sql.functions"] = funcs
+    sys.modules["pyspark.sql.types"] = types_mod
+
+    for name in type_names or []:
+        setattr(types_mod, name, type(name, (), {}))
+
+    def dummy(*args, **kwargs):
+        return None
+
+    for name in function_names or []:
+        setattr(funcs, name, dummy)
+
+    return pyspark
+
+
+def install_functions_package():
+    """Create a ``functions`` namespace package pointing at repo code."""
+    pkg_path = pathlib.Path(__file__).resolve().parents[1] / "functions"
+    functions_pkg = types.ModuleType("functions")
+    functions_pkg.__path__ = [str(pkg_path)]
+    sys.modules.setdefault("functions", functions_pkg)
+    return pkg_path
+
+
+def load_module(mod_name, path):
+    """Load a module from ``path`` under the provided name."""
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module


### PR DESCRIPTION
## Summary
- create `tests/utils.py` with utilities for fake pyspark modules and dynamic imports
- mark test directory as a package
- use the new helpers in tests to avoid repeated setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872efaadf9c83299d99095017cbfccc