### PR TITLE
Reorder dst_table_path at top of bronze configs

### DIFF
--- a/layer_01_bronze/bodies7days.json
+++ b/layer_01_bronze/bodies7days.json
@@ -1,6 +1,7 @@
 {
     "simple_settings": "true",
     "job_type": "bronze_standard_streaming",
+    "dst_table_path": "./tables/bronze/bodies7days",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "false",
     "readStreamOptions": {
@@ -638,6 +639,5 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history",
-    "dst_table_path": "./tables/bronze/bodies7days"
+    "history_schema": "history"
 }

--- a/layer_01_bronze/codex.json
+++ b/layer_01_bronze/codex.json
@@ -1,6 +1,7 @@
 {
     "simple_settings": "true",
     "job_type": "bronze_standard_streaming",
+    "dst_table_path": "./tables/bronze/codex",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "false",
     "readStreamOptions": {
@@ -62,6 +63,5 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history",
-    "dst_table_path": "./tables/bronze/codex"
+    "history_schema": "history"
 }

--- a/layer_01_bronze/powerPlay.json
+++ b/layer_01_bronze/powerPlay.json
@@ -1,6 +1,7 @@
 {
     "simple_settings": "true",
     "job_type": "bronze_standard_streaming",
+    "dst_table_path": "./tables/bronze/powerPlay",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "false",
     "readStreamOptions": {
@@ -102,6 +103,5 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history",
-    "dst_table_path": "./tables/bronze/powerPlay"
+    "history_schema": "history"
 }

--- a/layer_01_bronze/stations.json
+++ b/layer_01_bronze/stations.json
@@ -1,6 +1,7 @@
 {
     "simple_settings": "true",
     "job_type": "bronze_standard_streaming",
+    "dst_table_path": "./tables/bronze/stations",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "false",
     "readStreamOptions": {
@@ -318,6 +319,5 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history",
-    "dst_table_path": "./tables/bronze/stations"
+    "history_schema": "history"
 }

--- a/layer_01_bronze/systemsPopulated.json
+++ b/layer_01_bronze/systemsPopulated.json
@@ -1,6 +1,7 @@
 {
     "simple_settings": "true",
     "job_type": "bronze_standard_streaming",
+    "dst_table_path": "./tables/bronze/systemsPopulated",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "false",
     "readStreamOptions": {
@@ -1088,6 +1089,5 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history",
-    "dst_table_path": "./tables/bronze/systemsPopulated"
+    "history_schema": "history"
 }

--- a/layer_01_bronze/systemsWithCoordinates.json
+++ b/layer_01_bronze/systemsWithCoordinates.json
@@ -1,6 +1,7 @@
 {
     "simple_settings": "true",
     "job_type": "bronze_standard_streaming",
+    "dst_table_path": "./tables/bronze/systemsWithCoordinates",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "false",
     "readStreamOptions": {
@@ -73,6 +74,5 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history",
-    "dst_table_path": "./tables/bronze/systemsWithCoordinates"
+    "history_schema": "history"
 }

--- a/layer_01_bronze/systemsWithCoordinates7days.json
+++ b/layer_01_bronze/systemsWithCoordinates7days.json
@@ -1,6 +1,7 @@
 {
     "simple_settings": "true",
     "job_type": "bronze_standard_streaming",
+    "dst_table_path": "./tables/bronze/systemsWithCoordinates7days",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "false",
     "readStreamOptions": {
@@ -72,6 +73,5 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history",
-    "dst_table_path": "./tables/bronze/systemsWithCoordinates7days"
+    "history_schema": "history"
 }

--- a/layer_01_bronze/systemsWithoutCoordinates.json
+++ b/layer_01_bronze/systemsWithoutCoordinates.json
@@ -1,6 +1,7 @@
 {
     "simple_settings": "true",
     "job_type": "bronze_standard_streaming",
+    "dst_table_path": "./tables/bronze/systemsWithoutCoordinates",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "false",
     "readStreamOptions": {
@@ -78,6 +79,5 @@
         ],
         "type": "struct"
     },
-    "history_schema": "history",
-    "dst_table_path": "./tables/bronze/systemsWithoutCoordinates"
+    "history_schema": "history"
 }


### PR DESCRIPTION
## Summary
- move `dst_table_path` to immediately follow `job_type` in bronze job jsons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872faffadac83299ed58fc26fcfc425