### PR TITLE
Fix streaming shutdown issue

### DIFF
--- a/functions/write.py
+++ b/functions/write.py
@@ -34,7 +34,7 @@ def stream_write_table(df, settings, spark):
 
     writeStreamOptions = settings.get("writeStreamOptions")
 
-    (
+    return (
         df.writeStream
         .format("delta")
         .options(**writeStreamOptions)

--- a/scripts/run_ingest.py
+++ b/scripts/run_ingest.py
@@ -56,7 +56,9 @@ def run_pipeline(color: str, table: str, spark: SparkSession) -> None:
         df = read_function(settings, spark)
         df = transform_function(df, settings, spark)
         df = create_dqx_bad_records_table(df, settings, spark)
-        write_function(df, settings, spark)
+        query = write_function(df, settings, spark)
+        if hasattr(query, "awaitTermination"):
+            query.awaitTermination()
 
     if color == "bronze":
         create_bad_records_table(settings, spark)


### PR DESCRIPTION
## Summary
- return streaming query in `stream_write_table`
- wait for streaming queries to finish in `run_ingest`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872ff4866ec832986587102cfe034e4