### PR TITLE
Remove unused import from run_ingest

### DIFF
--- a/scripts/run_ingest.py
+++ b/scripts/run_ingest.py
@@ -19,7 +19,6 @@ from functions.utility import (
     get_function,
     create_bad_records_table,
     apply_job_type,
-    schema_exists,
     print_settings,
 )
 


### PR DESCRIPTION
## Summary
- remove `schema_exists` from `scripts/run_ingest.py` because it's unused

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68730554bc148329a69fac8b08612b82