### PR TITLE
Add landing zone arg to downloader

### DIFF
--- a/doc/downloader.md
+++ b/doc/downloader.md
@@ -1,0 +1,17 @@
+# Running the downloader
+
+The downloader script fetches daily and periodic dumps from the EDSM site and stores them in your landing zone. By default it writes to `./landing`, but you can supply an alternative path as the first argument.
+
+```bash
+# Uses ./landing as the landing zone root
+bash utilities/downloader.sh
+
+# Specify an alternative landing zone root
+bash utilities/downloader.sh /path/to/landing/root
+```
+
+The default behaviour matches the settings expected by the rest of the project, so running without arguments is usually sufficient. The script can also be executed through the Python wrapper:
+
+```bash
+python utilities/downloader.py [--script PATH_TO_DOWNLOADER_SH]
+```

--- a/utilities/downloader.sh
+++ b/utilities/downloader.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/bash
 
+# The first argument optionally specifies the base landing zone path. If not
+# provided, "./landing" is used which mirrors the expected local layout.
+landing_root="${1:-./landing}"
+
 tmp="/tmp/data"
-root="/Volumes/edsm/bronze/landing/data"
-marker_root="/Volumes/edsm/bronze/landing/markers"
+root="$landing_root/data"
+marker_root="$landing_root/markers"
 
 install -dv "$tmp" "$root" "$marker_root"
 touch "$marker_root/marker"


### PR DESCRIPTION
## Summary
- allow downloader.sh to accept an optional landing zone path
- document how to run the downloader
- switch default landing root to `./landing`

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687306ae2efc8329bafa8ef72c3b262f