### PR TITLE
Fix landing path bug in downloader

### DIFF
--- a/utilities/downloader.sh
+++ b/utilities/downloader.sh
@@ -2,7 +2,10 @@
 
 # The first argument optionally specifies the base landing zone path. If not
 # provided, "./landing" is used which mirrors the expected local layout.
+# Ensure we are always working with an absolute path so that any internal
+# directory changes do not break later file operations.
 landing_root="${1:-./landing}"
+landing_root="$(realpath "$landing_root")"
 
 tmp="/tmp/data"
 root="$landing_root/data"


### PR DESCRIPTION
## Summary
- ensure `landing_root` is resolved to an absolute path

This fixes failures where downloads couldn't be written because the script changed directories during execution.

## Testing
- `bash utilities/downloader.sh` *(interrupted after directory creation)*

------
https://chatgpt.com/codex/tasks/task_e_68730d7a036c832997d2cf7bcef13291