### PR TITLE
Support recursive file lookup

### DIFF
--- a/doc/downloader.md
+++ b/doc/downloader.md
@@ -15,3 +15,8 @@ The default behaviour matches the settings expected by the rest of the project, 
 ```bash
 python utilities/downloader.py [--script PATH_TO_DOWNLOADER_SH]
 ```
+
+Downloaded files are written beneath the ``landing`` directory using a dated
+subdirectory such as ``landing/data/20240101``. When loading these files without
+the ``recursiveFileLookup`` option your streaming job must point one directory
+below ``landing`` (for example ``landing/data``).

--- a/functions/utility.py
+++ b/functions/utility.py
@@ -142,7 +142,10 @@ def apply_job_type(settings):
             load_path = settings.get("readStream_load", "").rstrip("/")
             if "/" not in glob and "*" not in glob and "?" not in glob:
                 glob = f"**/{glob}"
-            settings["readStream_load"] = f"{load_path}/{glob}"
+            final_path = f"{load_path}/{glob}"
+            if "**" in glob:
+                read_opts.setdefault("recursiveFileLookup", "true")
+            settings["readStream_load"] = final_path
             settings["readStreamOptions"] = read_opts
 
     return settings

--- a/layer_01_bronze/bodies7days.json
+++ b/layer_01_bronze/bodies7days.json
@@ -8,6 +8,7 @@
         "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "bodies7days.json",
+        "recursiveFileLookup": "true",
         "multiline": "false"
     },
     "file_schema": {

--- a/layer_01_bronze/codex.json
+++ b/layer_01_bronze/codex.json
@@ -8,6 +8,7 @@
         "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "codex.json",
+        "recursiveFileLookup": "true",
         "multiline": "false"
     },
     "file_schema": {

--- a/layer_01_bronze/powerPlay.json
+++ b/layer_01_bronze/powerPlay.json
@@ -8,6 +8,7 @@
         "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "powerPlay.json",
+        "recursiveFileLookup": "true",
         "multiline": "false"
     },
     "file_schema": {

--- a/layer_01_bronze/stations.json
+++ b/layer_01_bronze/stations.json
@@ -8,6 +8,7 @@
         "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "stations.json",
+        "recursiveFileLookup": "true",
         "multiline": "false"
     },
     "file_schema": {

--- a/layer_01_bronze/systemsPopulated.json
+++ b/layer_01_bronze/systemsPopulated.json
@@ -8,6 +8,7 @@
         "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "systemsPopulated.json",
+        "recursiveFileLookup": "true",
         "multiline": "false"
     },
     "file_schema": {

--- a/layer_01_bronze/systemsWithCoordinates.json
+++ b/layer_01_bronze/systemsWithCoordinates.json
@@ -9,6 +9,7 @@
         "encoding": "utf-8",
         "cloudFiles.maxFilesPerTrigger": "1",
         "pathGlobFilter": "systemsWithCoordinates.json",
+        "recursiveFileLookup": "true",
         "multiline": "false"
     },
     "file_schema": {

--- a/layer_01_bronze/systemsWithCoordinates7days.json
+++ b/layer_01_bronze/systemsWithCoordinates7days.json
@@ -8,6 +8,7 @@
         "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "systemsWithCoordinates7days.json",
+        "recursiveFileLookup": "true",
         "multiline": "false"
     },
     "file_schema": {

--- a/layer_01_bronze/systemsWithoutCoordinates.json
+++ b/layer_01_bronze/systemsWithoutCoordinates.json
@@ -8,6 +8,7 @@
         "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "systemsWithoutCoordinates.json",
+        "recursiveFileLookup": "true",
         "multiline": "false"
     },
     "file_schema": {

--- a/tests/test_apply_job_type.py
+++ b/tests/test_apply_job_type.py
@@ -7,7 +7,12 @@ from tests import utils
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 # Provide minimal pyspark stubs required by utility
-utils.install_fake_pyspark(type_names=["StructType"])
+utils.install_fake_pyspark(function_names=["col", "row_number"], type_names=["StructType"])
+import types
+sys.modules["pyspark.sql.window"] = types.ModuleType("pyspark.sql.window")
+setattr(sys.modules["pyspark.sql.window"], "Window", type("Window", (), {}))
+StructType = sys.modules["pyspark.sql.types"].StructType
+setattr(StructType, "fromJson", classmethod(lambda cls, data: cls()))
 
 # Create a minimal 'functions' package so relative imports work
 pkg_path = utils.install_functions_package()
@@ -15,6 +20,8 @@ pkg_path = utils.install_functions_package()
 # Load utility dynamically
 utility_path = pkg_path / 'utility.py'
 utility = utils.load_module('functions.utility', utility_path)
+read_path = pkg_path / 'read.py'
+read = utils.load_module('functions.read', read_path)
 
 
 def test_path_glob_appended_to_load():
@@ -31,3 +38,46 @@ def test_path_glob_appended_to_load():
     result = utility.apply_job_type(settings)
     assert result['readStream_load'].endswith('/**/stations.json')
     assert 'pathGlobFilter' not in result['readStreamOptions']
+    assert result['readStreamOptions'].get('recursiveFileLookup') == 'true'
+
+
+class DummyReader:
+    def __init__(self):
+        self.calls = []
+        self.opts = {}
+
+    def format(self, fmt):
+        self.calls.append(('format', fmt))
+        return self
+
+    def options(self, **opts):
+        self.calls.append(('options', opts))
+        self.opts.update(opts)
+        return self
+
+    def schema(self, schema):
+        self.calls.append(('schema', schema))
+        return self
+
+    def load(self, path):
+        self.calls.append(('load', path))
+        return self
+
+
+class DummySpark:
+    def __init__(self):
+        self.readStream = DummyReader()
+
+
+def test_stream_read_files_recursive_option():
+    spark = DummySpark()
+    settings = {
+        'readStreamOptions': {
+            'format': 'json',
+            'recursiveFileLookup': 'true',
+        },
+        'readStream_load': 'landing/data/**/stations.json',
+        'file_schema': [],
+    }
+    read.stream_read_files(settings, spark)
+    assert spark.readStream.opts.get('recursiveFileLookup') == 'true'


### PR DESCRIPTION
## Summary
- add recursiveFileLookup option when pathGlobFilter expands to include '**'
- document landing directory structure
- ensure nested directory loading in tests
- set recursiveFileLookup on all bronze configs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737ccf87e883299ea81e75df00856b