### PR TITLE
Switch bronze configs to standard file_format option

### DIFF
--- a/functions/read.py
+++ b/functions/read.py
@@ -30,13 +30,14 @@ def stream_read_files(settings, spark):
     readStreamOptions = settings.get("readStreamOptions", {})
     readStream_load = settings.get("readStream_load")
 
-    # Determine the file format using either ``cloudFiles.format`` or ``format``
+    # Determine the file format using ``file_format`` or ``format`` options.
     file_format = (
-        readStreamOptions.get("cloudFiles.format")
+        settings.get("file_format")
         or readStreamOptions.get("format")
+        or readStreamOptions.get("cloudFiles.format")
     )
     if not file_format:
-        raise ValueError("File format must be specified in readStreamOptions")
+        raise ValueError("File format must be specified in settings")
 
     # Remove databricks specific options and ``cloudFiles.`` prefixes
     options = {}

--- a/layer_01_bronze/bodies7days.json
+++ b/layer_01_bronze/bodies7days.json
@@ -4,8 +4,8 @@
     "dst_table_path": "./tables/bronze/bodies7days",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "false",
+    "file_format": "json",
     "readStreamOptions": {
-        "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "bodies7days.json",
         "recursiveFileLookup": "true",

--- a/layer_01_bronze/codex.json
+++ b/layer_01_bronze/codex.json
@@ -4,8 +4,8 @@
     "dst_table_path": "./tables/bronze/codex",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "false",
+    "file_format": "json",
     "readStreamOptions": {
-        "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "codex.json",
         "recursiveFileLookup": "true",

--- a/layer_01_bronze/powerPlay.json
+++ b/layer_01_bronze/powerPlay.json
@@ -4,8 +4,8 @@
     "dst_table_path": "./tables/bronze/powerPlay",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "false",
+    "file_format": "json",
     "readStreamOptions": {
-        "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "powerPlay.json",
         "recursiveFileLookup": "true",

--- a/layer_01_bronze/stations.json
+++ b/layer_01_bronze/stations.json
@@ -4,8 +4,8 @@
     "dst_table_path": "./tables/bronze/stations",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "false",
+    "file_format": "json",
     "readStreamOptions": {
-        "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "stations.json",
         "recursiveFileLookup": "true",

--- a/layer_01_bronze/systemsPopulated.json
+++ b/layer_01_bronze/systemsPopulated.json
@@ -4,8 +4,8 @@
     "dst_table_path": "./tables/bronze/systemsPopulated",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "false",
+    "file_format": "json",
     "readStreamOptions": {
-        "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "systemsPopulated.json",
         "recursiveFileLookup": "true",

--- a/layer_01_bronze/systemsWithCoordinates.json
+++ b/layer_01_bronze/systemsWithCoordinates.json
@@ -4,10 +4,10 @@
     "dst_table_path": "./tables/bronze/systemsWithCoordinates",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "false",
+    "file_format": "json",
     "readStreamOptions": {
-        "cloudFiles.format": "json",
         "encoding": "utf-8",
-        "cloudFiles.maxFilesPerTrigger": "1",
+        "maxFilesPerTrigger": "1",
         "pathGlobFilter": "systemsWithCoordinates.json",
         "recursiveFileLookup": "true",
         "multiline": "false"

--- a/layer_01_bronze/systemsWithCoordinates7days.json
+++ b/layer_01_bronze/systemsWithCoordinates7days.json
@@ -4,8 +4,8 @@
     "dst_table_path": "./tables/bronze/systemsWithCoordinates7days",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "false",
+    "file_format": "json",
     "readStreamOptions": {
-        "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "systemsWithCoordinates7days.json",
         "recursiveFileLookup": "true",

--- a/layer_01_bronze/systemsWithoutCoordinates.json
+++ b/layer_01_bronze/systemsWithoutCoordinates.json
@@ -4,8 +4,8 @@
     "dst_table_path": "./tables/bronze/systemsWithoutCoordinates",
     "derived_ingest_time_regex": "/(\\d{8})/",
     "add_derived_ingest_time": "false",
+    "file_format": "json",
     "readStreamOptions": {
-        "cloudFiles.format": "json",
         "encoding": "utf-8",
         "pathGlobFilter": "systemsWithoutCoordinates.json",
         "recursiveFileLookup": "true",

--- a/tests/test_apply_job_type.py
+++ b/tests/test_apply_job_type.py
@@ -29,8 +29,8 @@ def test_path_glob_appended_to_load():
         'simple_settings': 'true',
         'job_type': 'bronze_standard_streaming',
         'dst_table_name': 'cat.bronze.tbl',
+        'file_format': 'json',
         'readStreamOptions': {
-            'cloudFiles.format': 'json',
             'pathGlobFilter': 'stations.json'
         },
         'file_schema': []


### PR DESCRIPTION
## Summary
- adjust stream_read_files to read `file_format` from settings
- rename `cloudFiles.format` to `file_format` in bronze JSON configs
- update tests for the new option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737fbcae3c8329b6c96389b74c89b2