### PR TITLE
Fix multi-directory streaming load

### DIFF
--- a/functions/read.py
+++ b/functions/read.py
@@ -93,13 +93,18 @@ def stream_read_files(settings, spark):
             raise RuntimeError("No new files to process")
         load_args = dirs
 
-    return (
+    reader = (
         spark.readStream
         .format(file_format)
         .options(**options)
         .schema(schema)
-        .load(*load_args)
     )
+
+    df = reader.load(load_args[0])
+    for path in load_args[1:]:
+        df = df.union(reader.load(path))
+
+    return df
 
 
 def stream_read_table(settings, spark):

--- a/tests/test_apply_job_type.py
+++ b/tests/test_apply_job_type.py
@@ -64,6 +64,10 @@ class DummyReader:
         self.calls.append(('load', paths))
         return self
 
+    def union(self, other):
+        self.calls.append(('union', other))
+        return self
+
 
 class DummySpark:
     def __init__(self):
@@ -83,7 +87,8 @@ def test_stream_read_files_list_unseen_dirs():
     with mock.patch.object(read, 'list_unseen_dirs', return_value=['a', 'b']) as m:
         read.stream_read_files(settings, spark)
     assert m.called
-    assert spark.readStream.calls[-1] == ('load', ('a', 'b'))
+    loads = [c for c in spark.readStream.calls if c[0] == 'load']
+    assert loads == [('load', ('a',)), ('load', ('b',))]
 
 
 def test_stream_read_files_rejects_recursive_lookup():


### PR DESCRIPTION
## Summary
- handle multiple directories in `stream_read_files`
- update tests for new loading logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68738a09bd5c832998064a9da639db16