### PR TITLE
Fix pathGlobFilter removal

### DIFF
--- a/functions/utility.py
+++ b/functions/utility.py
@@ -134,14 +134,13 @@ def apply_job_type(settings):
         # filename is supplied, prepend ``**/`` so the glob is applied
         # recursively.
         read_opts = settings.get("readStreamOptions", {})
-        glob = read_opts.pop("pathGlobFilter", None)
+        glob = read_opts.get("pathGlobFilter")
         if glob:
             load_path = settings.get("readStream_load", "").rstrip("/")
             if "/" not in glob and "*" not in glob and "?" not in glob:
                 glob = f"**/{glob}"
             final_path = f"{load_path}/{glob}"
             settings["readStream_load"] = final_path
-            settings["readStreamOptions"] = read_opts
 
     return settings
 

--- a/tests/test_apply_job_type.py
+++ b/tests/test_apply_job_type.py
@@ -39,7 +39,7 @@ def test_path_glob_appended_to_load():
     }
     result = utility.apply_job_type(settings)
     assert result['readStream_load'].endswith('/**/stations.json')
-    assert 'pathGlobFilter' not in result['readStreamOptions']
+    assert result['readStreamOptions']['pathGlobFilter'] == 'stations.json'
 
 
 class DummyReader:


### PR DESCRIPTION
## Summary
- preserve `pathGlobFilter` in `readStreamOptions`
- update test to reflect the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873953f91c88329a536c1de2db4b82b