### PR TITLE
Add directory listing output for streaming file discovery

### DIFF
--- a/functions/read.py
+++ b/functions/read.py
@@ -90,6 +90,10 @@ def stream_read_files(settings, spark):
         dirs = list_unseen_dirs(base_path, pattern, checkpoint)
         if not dirs:
             raise RuntimeError("No new files to process")
+
+        print("Discovered directories to process:")
+        print(json.dumps(dirs, indent=4))
+
         load_args = dirs
 
     reader = (


### PR DESCRIPTION
## Summary
- print directories discovered when searching for new files in `stream_read_files`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873b0a12a44832999a494e999cacbc1