### PR TITLE
Add verbose flag to control file schema printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ python scripts/run_ingest.py bronze stations
 
 Specify the layer (`bronze`, `silver`, or `gold`) and the table name (without the
 `.json` extension). Use the `--master` argument to override the Spark master URL
-if necessary.
+if necessary. Pass `-v` to include the full settings including the file schema.
 ## Running the full job
 
 Use the `utilities/run_job.py` script to execute the downloader and all ingest tasks without relying on Databricks APIs.
@@ -19,4 +19,5 @@ Use the `utilities/run_job.py` script to execute the downloader and all ingest t
 python utilities/run_job.py
 ```
 
-Use `--master` to override the Spark master URL if necessary.
+Use `--master` to override the Spark master URL if necessary. Include `-v` to
+print the full settings for each table.

--- a/functions/utility.py
+++ b/functions/utility.py
@@ -30,13 +30,15 @@ def create_spark_session(master: str, app_name: str):
     return builder.getOrCreate()
 
 
-def print_settings(job_settings, settings, color, table):
+def print_settings(job_settings, settings, color, table, verbose=False):
     """Print job and table settings in plain text."""
 
     print(f"Dictionary from {color}_settings.json:")
     print(json.dumps(job_settings, indent=4))
 
     print(f"Derived contents of {table}.json:")
+    if not verbose and "file_schema" in settings:
+        settings = {k: v for k, v in settings.items() if k != "file_schema"}
     print(json.dumps(settings, indent=4))
 
 

--- a/scripts/run_ingest.py
+++ b/scripts/run_ingest.py
@@ -33,7 +33,7 @@ def load_settings(color: str, table: str) -> dict:
     return apply_job_type(settings)
 
 
-def run_pipeline(color: str, table: str, spark: SparkSession) -> None:
+def run_pipeline(color: str, table: str, spark: SparkSession, verbose: bool = False) -> None:
     """Execute the ingest pipeline for the given table."""
     settings = load_settings(color, table)
     dst_table_name = settings.get("dst_table_name")
@@ -42,7 +42,7 @@ def run_pipeline(color: str, table: str, spark: SparkSession) -> None:
     if not dst_table_name and not dst_table_path:
         raise KeyError("dst_table_name or dst_table_path must be provided")
 
-    print_settings({"table": table}, settings, color, table)
+    print_settings({"table": table}, settings, color, table, verbose=verbose)
 
     if "pipeline_function" in settings:
         pipeline_function = get_function(settings["pipeline_function"])
@@ -68,12 +68,13 @@ def main() -> None:
     parser.add_argument("color", choices=["bronze", "silver", "gold"], help="Layer color")
     parser.add_argument("table", help="Table name (without .json)")
     parser.add_argument("--master", default="local[*]", help="Spark master URL")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Print full settings including file schema")
     args = parser.parse_args()
 
     spark = create_spark_session(args.master, "edsm-ingest")
 
     try:
-        run_pipeline(args.color, args.table, spark)
+        run_pipeline(args.color, args.table, spark, verbose=args.verbose)
     finally:
         spark.stop()
 

--- a/utilities/run_job.py
+++ b/utilities/run_job.py
@@ -31,7 +31,7 @@ def _discover_tables(color: str) -> list[str]:
     return sorted(Path(p).stem for p in paths)
 
 
-def run_job(master: str) -> None:
+def run_job(master: str, verbose: bool = False) -> None:
     """Execute the downloader and ingest pipelines."""
 
     validate_settings()
@@ -44,10 +44,10 @@ def run_job(master: str) -> None:
         subprocess.check_call(["bash", str(downloader)])
 
         for table in _discover_tables("bronze"):
-            run_pipeline("bronze", table, spark)
+            run_pipeline("bronze", table, spark, verbose=verbose)
 
         for table in _discover_tables("silver"):
-            run_pipeline("silver", table, spark)
+            run_pipeline("silver", table, spark, verbose=verbose)
     finally:
         spark.stop()
 
@@ -57,8 +57,9 @@ def main() -> None:
     parser.add_argument(
         "--master", default="local[*]", help="Spark master URL"
     )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Print full settings including file schema")
     args = parser.parse_args()
-    run_job(args.master)
+    run_job(args.master, verbose=args.verbose)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow `print_settings()` to omit `file_schema` unless verbose
- add `-v/--verbose` option to `run_ingest.py`
- add verbose flag propagation in `run_job.py`
- document verbose usage in README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873b079540083299ab874db84443512