### PR TITLE
Fix argument order in inspect_checkpoint_folder script

### DIFF
--- a/utilities/inspect_checkpoint_folder.py
+++ b/utilities/inspect_checkpoint_folder.py
@@ -29,7 +29,7 @@ def main() -> None:
 
     spark = create_spark_session(args.master, "inspect-checkpoints")
     try:
-        inspect_checkpoint_folder(settings, args.table, spark)
+        inspect_checkpoint_folder(args.table, settings, spark)
     finally:
         spark.stop()
 


### PR DESCRIPTION
## Summary
- call `inspect_checkpoint_folder` with the correct argument order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873b50a644c83299e3064a34b6d964a