### PR TITLE
Fix checkpoint folder inspection

### DIFF
--- a/docs/utilities/inspect_checkpoint_folder.md
+++ b/docs/utilities/inspect_checkpoint_folder.md
@@ -8,3 +8,7 @@ python utilities/inspect_checkpoint_folder.py TABLE_NAME [--master MASTER_URL]
 
 `TABLE_NAME` should match one of the JSON files in `layer_02_silver` without the extension.
 Use `--master` to specify the Spark master URL.
+
+The script applies the `job_type` defaults from the settings file, which usually
+populate `writeStreamOptions.checkpointLocation`. If a checkpoint location
+cannot be determined after applying the job type, a descriptive error is raised.

--- a/functions/utility.py
+++ b/functions/utility.py
@@ -236,8 +236,11 @@ def truncate_table_if_exists(table_name, spark):
 
 def inspect_checkpoint_folder(table_name, settings, spark):
     """Print batch to version mapping from a Delta checkpoint folder."""
-
     checkpoint_path = settings.get("writeStreamOptions", {}).get("checkpointLocation")
+    if not checkpoint_path:
+        raise ValueError(
+            "Missing 'writeStreamOptions.checkpointLocation' in the settings file"
+        )
     checkpoint_path = checkpoint_path.rstrip("/")
     offsets_path = f"{checkpoint_path}/offsets"
 

--- a/utilities/inspect_checkpoint_folder.py
+++ b/utilities/inspect_checkpoint_folder.py
@@ -10,7 +10,11 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from functions.utility import create_spark_session, inspect_checkpoint_folder
+from functions.utility import (
+    create_spark_session,
+    inspect_checkpoint_folder,
+    apply_job_type,
+)
 from functions.config import PROJECT_ROOT
 
 
@@ -26,6 +30,7 @@ def main() -> None:
 
     settings_path = table_map[args.table]
     settings = json.loads(Path(settings_path).read_text())
+    settings = apply_job_type(settings)
 
     spark = create_spark_session(args.master, "inspect-checkpoints")
     try:


### PR DESCRIPTION
## Summary
- use `apply_job_type` in the checkpoint inspector utility so defaults provide the checkpoint path
- document that job type expansion supplies the checkpoint location

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873c2066b8c8329b3e54e31323d489c