### PR TITLE
Enhance checkpoint inspection utility

### DIFF
--- a/docs/utilities/inspect_checkpoint_folder.md
+++ b/docs/utilities/inspect_checkpoint_folder.md
@@ -3,12 +3,16 @@
 `utilities/inspect_checkpoint_folder.py` inspects a Delta checkpoint directory for a given table.
 
 ```bash
-python utilities/inspect_checkpoint_folder.py TABLE_NAME [--master MASTER_URL]
+python utilities/inspect_checkpoint_folder.py COLOR TABLE_NAME [--master MASTER_URL]
 ```
 
-`TABLE_NAME` should match one of the JSON files in `layer_02_silver` without the extension.
-Use `--master` to specify the Spark master URL.
+`COLOR` must be either `bronze` or `silver` and selects the layer of settings to inspect. `TABLE_NAME` should match one of the JSON files in the corresponding layer without the extension. Use `--master` to specify the Spark master URL.
 
 The script applies the `job_type` defaults from the settings file, which usually
 populate `writeStreamOptions.checkpointLocation`. If a checkpoint location
 cannot be determined after applying the job type, a descriptive error is raised.
+
+When inspecting a silver table the output shows which bronze version was read by
+each streaming batch. When inspecting a bronze table the script lists the
+directories processed in each batch based on the information stored in the
+checkpoint's `sources` directory.

--- a/utilities/inspect_checkpoint_folder.py
+++ b/utilities/inspect_checkpoint_folder.py
@@ -19,14 +19,27 @@ from functions.config import PROJECT_ROOT
 
 
 def main() -> None:
-    settings_dir = PROJECT_ROOT / "layer_02_silver"
-    paths = glob(str(settings_dir / "*.json"))
-    table_map = {Path(p).stem: p for p in paths}
+    layer_map = {
+        "silver": PROJECT_ROOT / "layer_02_silver",
+        "bronze": PROJECT_ROOT / "layer_01_bronze",
+    }
 
     parser = argparse.ArgumentParser(description="Inspect checkpoint directory")
-    parser.add_argument("table", choices=table_map.keys(), help="Table name")
+    parser.add_argument(
+        "color",
+        choices=layer_map.keys(),
+        help="Table color (bronze or silver)",
+    )
+    parser.add_argument("table", help="Table name")
     parser.add_argument("--master", default="local[*]", help="Spark master URL")
+
     args = parser.parse_args()
+
+    settings_dir = layer_map[args.color]
+    paths = glob(str(settings_dir / "*.json"))
+    table_map = {Path(p).stem: p for p in paths}
+    if args.table not in table_map:
+        parser.error(f"Unknown table '{args.table}' for color '{args.color}'")
 
     settings_path = table_map[args.table]
     settings = json.loads(Path(settings_path).read_text())


### PR DESCRIPTION
## Summary
- support bronze and silver checkpoints in `inspect_checkpoint_folder`
- allow selecting table color on the CLI
- document new usage
- detect bronze checkpoints by presence of `sources` and parse batch files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873c3af0884832996716093d8d6920d