### PR TITLE
Update ingest_time_column in silver configs

### DIFF
--- a/layer_02_silver/bodies7days.json
+++ b/layer_02_silver/bodies7days.json
@@ -15,5 +15,5 @@
     "data_type_map": {
         "date": "timestamp"
     },
-    "ingest_time_column": "derived_ingest_time"
+    "ingest_time_column": "ingest_time"
 }

--- a/layer_02_silver/codex.json
+++ b/layer_02_silver/codex.json
@@ -22,5 +22,5 @@
     "data_type_map": {
         "date": "timestamp"
     },
-    "ingest_time_column": "derived_ingest_time"
+    "ingest_time_column": "ingest_time"
 }

--- a/layer_02_silver/powerPlay.json
+++ b/layer_02_silver/powerPlay.json
@@ -3,7 +3,7 @@
     "job_type": "silver_scd2_streaming",
     "src_table_path": "./tables/bronze/powerPlay",
     "dst_table_path": "./tables/silver/powerPlay",
-    "ingest_time_column": "derived_ingest_time",
+    "ingest_time_column": "ingest_time",
     "business_key": [
         "id",
         "power"

--- a/layer_02_silver/stations.json
+++ b/layer_02_silver/stations.json
@@ -28,5 +28,5 @@
     "data_type_map": {
         "date": "timestamp"
     },
-    "ingest_time_column": "derived_ingest_time"
+    "ingest_time_column": "ingest_time"
 }

--- a/layer_02_silver/systemsPopulated.json
+++ b/layer_02_silver/systemsPopulated.json
@@ -22,5 +22,5 @@
     "data_type_map": {
         "date": "timestamp"
     },
-    "ingest_time_column": "derived_ingest_time"
+    "ingest_time_column": "ingest_time"
 }

--- a/layer_02_silver/systemsWithCoordinates.json
+++ b/layer_02_silver/systemsWithCoordinates.json
@@ -16,7 +16,7 @@
     "data_type_map": {
         "date": "timestamp"
     },
-    "ingest_time_column": "derived_ingest_time",
+    "ingest_time_column": "ingest_time",
     "quality_checks": [
         {
             "name": "coords.x_is_not_null",

--- a/layer_02_silver/systemsWithoutCoordinates.json
+++ b/layer_02_silver/systemsWithoutCoordinates.json
@@ -15,5 +15,5 @@
     "data_type_map": {
         "date": "timestamp"
     },
-    "ingest_time_column": "derived_ingest_time"
+    "ingest_time_column": "ingest_time"
 }


### PR DESCRIPTION
## Summary
- update silver JSON configs to use `ingest_time` for `ingest_time_column`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873eb5ebc4483298d07349b087e6f3d