### PR TITLE
Add validation and initialization to run_pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ print the full settings for each table.
 ## Ingest all tables
 
 `scripts/run_pipeline.py` runs `scripts/run_ingest.py` for every table defined
-in the settings files. Bronze tables are ingested first followed by silver
-tables.
+in the settings files. Before ingestion starts it validates the settings files
+and creates any missing empty tables based on the JSON definitions. Bronze
+tables are ingested first followed by silver tables.
 
 ```bash
 python scripts/run_pipeline.py

--- a/docs/utilities/run_ingest_pipeline.md
+++ b/docs/utilities/run_ingest_pipeline.md
@@ -1,9 +1,0 @@
-# Ingest all tables
-
-`scripts/run_pipeline.py` invokes `scripts/run_ingest.py` for every table defined in the settings files. It first ingests all bronze tables and then all silver tables.
-
-```bash
-python scripts/run_pipeline.py
-```
-
-The stdout and stderr from each ingest run are written to files in the `logs` directory. Use `--master` to override the Spark master URL and `-v` to pass the verbose flag to `run_ingest.py`.

--- a/docs/utilities/run_pipeline.md
+++ b/docs/utilities/run_pipeline.md
@@ -1,0 +1,9 @@
+# Ingest all tables
+
+`scripts/run_pipeline.py` invokes `scripts/run_ingest.py` for every table defined in the settings files. Before any ingest jobs run it validates the JSON settings and initialises empty tables if needed. It then ingests all bronze tables followed by all silver tables.
+
+```bash
+python scripts/run_pipeline.py
+```
+
+The stdout and stderr from each ingest run are written to files in the `logs` directory. Use `--master` to override the Spark master URL and `-v` to pass the verbose flag to `run_ingest.py`.


### PR DESCRIPTION
## Summary
- update settings sanity checks and initialization to use `dst_table_path`
- create helper to test filesystem paths
- run `validate_settings` and `initialize_empty_tables` in `run_pipeline.py`
- rename docs utility file to `run_pipeline.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873f05cfe408329b28349bcf2c1cf4b